### PR TITLE
Update CorreiosConsulta.php

### DIFF
--- a/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
+++ b/src/Cagartner/CorreiosConsulta/CorreiosConsulta.php
@@ -173,7 +173,7 @@ class CorreiosConsulta
                             $innerHTML .= $child->ownerDocument->saveXML($child);
                         }
                         $texto = preg_replace("/&#?[a-z0-9]+;/i", "", $innerHTML);
-                        $itens[] = trim($texto);
+                        $itens[] = preg_replace(['(\s+)u', '(^\s|\s$)u'], [' ', ''], $texto);
                     }
                     $dados = array();
                     $dados['logradouro'] = trim($itens[0]);


### PR DESCRIPTION
Normalização de espaço em branco retornado. O DOMDocument no PHP retorna cadeias de caracteres ao invés de espaço em si. Substituída a função trim() da linha 176 por expressão regular.